### PR TITLE
added a launcher.sh and updated the readme with instructions on how t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ change the file permission of launcher sh (if required)
 ```chmod 755 launcher.sh
 ```
 
-create a logs directory in home 
-```mkdir logs```
-
 add it as a cron job 
 ```
 sudo crontab -e
@@ -53,7 +50,7 @@ sudo crontab -e
 
 add the following line
 ```
-@reboot sh /home/umbrel/warden/warden_terminal//launcher.sh >/home/umbrel/logs/cronlog 2>&1
+@reboot sh /home/umbrel/warden/warden_terminal/launcher.sh &
 ```
 
 reboot

--- a/README.md
+++ b/README.md
@@ -33,6 +33,37 @@ pip3 install -r requirements.txt
 python3 node_warden.py
 ```
 
+##Auto load warden on start up on  PI
+look at launcer.sh and make sure it is pointing to the correct directory where warden terminal is
+```nano launcher.sh
+```
+
+change the file permission of launcher sh (if required)
+
+```chmod 755 launcher.sh
+```
+
+create a logs directory in home 
+```mkdir logs```
+
+add it as a cron job 
+```
+sudo crontab -e
+```
+
+add the following line
+```
+@reboot sh /home/umbrel/warden/warden_terminal//launcher.sh >/home/umbrel/logs/cronlog 2>&1
+```
+
+reboot
+```sudo reboot
+```
+
+
+
+
+
 You need Tor Running for the app to work. Instructions [here](https://2019.www.torproject.org/docs/debian.html.en).
 
 The `config.ini` file can be edited with:

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,0 +1,9 @@
+/sh
+# launcher.sh
+# navigate to home directory, then to this directory, then execute python script, then back home
+
+cd home/umbrel/warden/warden_terminal
+python3 node_warden.py
+cd /
+
+

--- a/launcher.sh
+++ b/launcher.sh
@@ -2,6 +2,7 @@
 # launcher.sh
 # navigate to home directory, then to this directory, then execute python script, then back home
 
+cd /
 cd home/umbrel/warden/warden_terminal
 python3 node_warden.py
 cd /


### PR DESCRIPTION
A simple update to allow auto load via cron on a raspberry PI

Steps required:

ssh into the PI

cd warden/warden_terminal
nano launcher.sh (change directory of the sh file if required)
chmod 755 launcher.sh (change the file permission is required)
cd ../..
mkdir logs (make a log directory for corn failures)
sudo crontab -e (add the corn)
@reboot sh /home/umbrel/warden/warden_terminal//launcher.sh >/home/umbrel/logs/cronlog 2>&1
sudo reboot 


