### PR TITLE
fix naming of rpc config

### DIFF
--- a/data.py
+++ b/data.py
@@ -790,7 +790,7 @@ def data_btc_rpc_info(use_cache=True):
 
     # Create Synch progress bar
     try:
-        perc_c = int(bci['verificationprogress'] * 100)
+        perc_c = int(float(bci['verificationprogress']) * 100)
         synch_bar = printProgressBar(iteration=round(perc_c, 2),
                                      total=100,
                                      suffix=(f'{round(perc_c, 2)}%'),

--- a/data.py
+++ b/data.py
@@ -790,7 +790,7 @@ def data_btc_rpc_info(use_cache=True):
 
     # Create Synch progress bar
     try:
-        perc_c = int(bci['verificationprogress']) * 100
+        perc_c = int(bci['verificationprogress'] * 100)
         synch_bar = printProgressBar(iteration=round(perc_c, 2),
                                      total=100,
                                      suffix=(f'{round(perc_c, 2)}%'),

--- a/rpc.py
+++ b/rpc.py
@@ -29,10 +29,10 @@ def rpc_connect():
     else:
         # Get the config info as default
         if config['BITCOIN_RPC'].get('ip_address') != 'None':
-            rpc_user = config['BITCOIN_RPC'].get('BTCEXP_BITCOIND_USER')
-            rpc_password = config['BITCOIN_RPC'].get('BTCEXP_BITCOIND_PASS')
-            rpc_ip = config['BITCOIN_RPC'].get('BTCEXP_BITCOIND_HOST')
-            rpc_port = config['BITCOIN_RPC'].get('BTCEXP_BITCOIND_PORT')
+            rpc_user = config['BITCOIN_RPC'].get('user')
+            rpc_password = config['BITCOIN_RPC'].get('password')
+            rpc_ip = config['BITCOIN_RPC'].get('ip_address')
+            rpc_port = config['BITCOIN_RPC'].get('port')
         else:
             # If not, let's try to get the environment variables
             # These are standard for Umbrel for example


### PR DESCRIPTION
- using the var names for the config file
- the progress bar was always 0%, because rpc=0.9999 becomes to 0%